### PR TITLE
binary: add SharedPtr struct to represent shared memory range feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Support `NACL` extension in Chapter 15
 - Support `STA` extension in Chapter 16
 - Add new SBI error `NoShmem`
+- binary: add SharedPtr struct to represent shared memory range feature.
 
 ### Modified
 


### PR DESCRIPTION
Implemented traits for SharedPtr:
- Clone, Copy for *const T and *mut T are both Clone and Copy
- !Send and !Sync, by using PhantomData over a raw pointer

`Physical<P>` is used in DBCN extension as a wrapper around immutable or mutable buffers (`Physical<&[u8]>` and `Physical<&mut [u8]>`, while `SharedPtr<T>` is used by STA and NACL to represent shared memory (`SharedPtr<[u8; 64]>`, etc.).